### PR TITLE
Rename sdk to aptos-indexer-processor-sdk

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -117,6 +117,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "aptos-indexer-processor-sdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-indexer-transaction-stream",
+ "aptos-protos",
+ "async-trait",
+ "derive_builder",
+ "futures",
+ "hex",
+ "instrumented-channel",
+ "kanal",
+ "mockall",
+ "num_cpus",
+ "once_cell",
+ "petgraph",
+ "prometheus",
+ "prometheus-client",
+ "serde",
+ "thiserror",
+ "tokio",
+ "url",
+ "warp",
+]
+
+[[package]]
 name = "aptos-indexer-transaction-stream"
 version = "0.1.0"
 source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=3c8896b489062ce0510c5e4162366db753b59499#3c8896b489062ce0510c5e4162366db753b59499"
@@ -2754,36 +2780,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sdk"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "aptos-indexer-transaction-stream",
- "aptos-protos",
- "async-trait",
- "derive_builder",
- "futures",
- "instrumented-channel",
- "kanal",
- "mockall",
- "num_cpus",
- "once_cell",
- "petgraph",
- "prometheus",
- "prometheus-client",
- "serde",
- "thiserror",
- "tokio",
- "url",
- "warp",
-]
-
-[[package]]
 name = "sdk-examples"
 version = "0.1.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "aptos-indexer-processor-sdk",
  "aptos-indexer-transaction-stream",
  "aptos-protos",
  "async-trait",
@@ -2807,7 +2809,6 @@ dependencies = [
  "num_cpus",
  "postgres-native-tls",
  "rayon",
- "sdk",
  "sdk-server-framework",
  "serde",
  "serde_json",
@@ -2825,6 +2826,7 @@ name = "sdk-server-framework"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "aptos-indexer-processor-sdk",
  "aptos-system-utils",
  "async-trait",
  "autometrics",
@@ -2832,7 +2834,6 @@ dependencies = [
  "clap",
  "instrumented-channel",
  "prometheus-client",
- "sdk",
  "serde",
  "serde_yaml",
  "tempfile",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/aptos-labs/aptos-indexer-processors-sdk"
 rust-version = "1.75"
 
 [workspace.dependencies]
+aptos-indexer-processor-sdk = { path = "sdk" }
 instrumented-channel = { path = "instrumented-channel" }
-sdk = { path = "sdk" }
 sdk-server-framework = { path = 'sdk-server-framework' }
 
 ahash = { version = "0.8.7", features = ["serde"] }

--- a/rust/sdk-examples/Cargo.toml
+++ b/rust/sdk-examples/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 ahash = { workspace = true }
 anyhow = { workspace = true }
+aptos-indexer-processor-sdk = { workspace = true }
 aptos-indexer-transaction-stream = { workspace = true }
 aptos-protos = { workspace = true }
 async-trait = { workspace = true }
@@ -28,7 +29,6 @@ kanal = { workspace = true }
 lazy_static = { workspace = true }
 num_cpus = { workspace = true }
 rayon = { workspace = true }
-sdk = { workspace = true }
 sdk-server-framework = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/sdk-examples/src/events_processor/events_extractor.rs
+++ b/rust/sdk-examples/src/events_processor/events_extractor.rs
@@ -1,12 +1,12 @@
 use super::events_models::EventModel;
-use aptos_protos::transaction::v1::{transaction::TxnData, Transaction};
-use async_trait::async_trait;
-use rayon::prelude::*;
-use sdk::{
+use aptos_indexer_processor_sdk::{
     steps::{async_step::AsyncRunType, AsyncStep},
     traits::{NamedStep, Processable},
     types::transaction_context::TransactionContext,
 };
+use aptos_protos::transaction::v1::{transaction::TxnData, Transaction};
+use async_trait::async_trait;
+use rayon::prelude::*;
 
 pub struct EventsExtractor
 where

--- a/rust/sdk-examples/src/events_processor/events_storer.rs
+++ b/rust/sdk-examples/src/events_processor/events_storer.rs
@@ -6,16 +6,16 @@ use crate::{
 };
 use ahash::AHashMap;
 use anyhow::{Context, Result};
+use aptos_indexer_processor_sdk::{
+    steps::{async_step::AsyncRunType, AsyncStep},
+    traits::{NamedStep, Processable},
+    types::transaction_context::TransactionContext,
+};
 use async_trait::async_trait;
 use diesel::{
     pg::{upsert::excluded, Pg},
     query_builder::QueryFragment,
     ExpressionMethods,
-};
-use sdk::{
-    steps::{async_step::AsyncRunType, AsyncStep},
-    traits::{NamedStep, Processable},
-    types::transaction_context::TransactionContext,
 };
 
 pub struct EventsStorer

--- a/rust/sdk-examples/src/events_processor/processor.rs
+++ b/rust/sdk-examples/src/events_processor/processor.rs
@@ -1,13 +1,13 @@
 use super::{events_extractor::EventsExtractor, events_storer::EventsStorer};
 use crate::config::indexer_processor_config::DbConfig;
 use anyhow::Result;
-use aptos_indexer_transaction_stream::config::TransactionStreamConfig;
-use instrumented_channel::instrumented_bounded_channel;
-use sdk::{
+use aptos_indexer_processor_sdk::{
     builder::ProcessorBuilder,
     steps::{TimedBuffer, TransactionStreamStep},
     traits::{IntoRunnableStep, RunnableStepWithInputReceiver},
 };
+use aptos_indexer_transaction_stream::config::TransactionStreamConfig;
+use instrumented_channel::instrumented_bounded_channel;
 use std::time::Duration;
 
 pub struct EventsProcessor {

--- a/rust/sdk-server-framework/Cargo.toml
+++ b/rust/sdk-server-framework/Cargo.toml
@@ -12,6 +12,8 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-indexer-processor-sdk = { workspace = true }
+
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 autometrics = { workspace = true }
@@ -19,7 +21,6 @@ backtrace = { workspace = true }
 clap = { workspace = true }
 instrumented-channel = { workspace = true }
 prometheus-client = { workspace = true }
-sdk = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }

--- a/rust/sdk-server-framework/src/lib.rs
+++ b/rust/sdk-server-framework/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 
 use anyhow::{Context, Result};
+use aptos_indexer_processor_sdk::steps::step_metrics::init_step_metrics_registry;
 #[cfg(target_os = "linux")]
 use aptos_system_utils::profiling::start_cpu_profiling;
 use autometrics::settings::AutometricsSettings;
@@ -8,7 +9,6 @@ use backtrace::Backtrace;
 use clap::Parser;
 use instrumented_channel::channel_metrics::init_channel_metrics_registry;
 use prometheus_client::registry::Registry;
-use sdk::steps::step_metrics::init_step_metrics_registry;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(target_os = "linux")]
 use std::convert::Infallible;

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sdk"
+name = "aptos-indexer-processor-sdk"
 version = "0.1.0"
 edition = "2021"
 
@@ -10,6 +10,7 @@ aptos-protos = { workspace = true }
 async-trait = { workspace = true }
 derive_builder = { workspace = true }
 futures = { workspace = true }
+hex = { workspace = true }
 instrumented-channel = { workspace = true }
 kanal = { workspace = true }
 mockall = { workspace = true }

--- a/rust/sdk/src/main.rs
+++ b/rust/sdk/src/main.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
-use aptos_indexer_transaction_stream::config::TransactionStreamConfig;
-use sdk::{
+use aptos_indexer_processor_sdk::{
     builder::ProcessorBuilder,
     steps::{TimedBuffer, TransactionStreamStep},
     traits::IntoRunnableStep,
 };
+use aptos_indexer_transaction_stream::config::TransactionStreamConfig;
 use std::time::Duration;
 use url::Url;
 
@@ -74,15 +74,15 @@ async fn run_processor() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use async_trait::async_trait;
-    use instrumented_channel::instrumented_bounded_channel;
-    use sdk::{
-        builder::ProcessorBuilder,
-        steps::{AsyncStep, RunnableAsyncStep, TimedBuffer},
+    use super::*;
+    use aptos_indexer_processor_sdk::{
+        steps::{AsyncStep, RunnableAsyncStep},
         test::{steps::pass_through_step::PassThroughStep, utils::receive_with_timeout},
-        traits::{IntoRunnableStep, NamedStep, Processable, RunnableStepWithInputReceiver},
+        traits::{NamedStep, Processable, RunnableStepWithInputReceiver},
         types::transaction_context::TransactionContext,
     };
+    use async_trait::async_trait;
+    use instrumented_channel::instrumented_bounded_channel;
     use std::time::Duration;
 
     #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Importing a crate called `sdk` is a bit vague and prone to future crate name collisions.