### PR TITLE
Expose register_probes_and_metrics_handler function

### DIFF
--- a/rust/sdk-server-framework/src/lib.rs
+++ b/rust/sdk-server-framework/src/lib.rs
@@ -159,7 +159,7 @@ pub fn setup_logging() {
 }
 
 /// Register readiness and liveness probes and set up metrics endpoint.
-async fn register_probes_and_metrics_handler(port: u16) {
+pub async fn register_probes_and_metrics_handler(port: u16) {
     let mut registry = <Registry>::default();
     init_step_metrics_registry(&mut registry);
     init_channel_metrics_registry(&mut registry);


### PR DESCRIPTION
^ for no code indexer 

We are defining a separate, generic config for the no code processor, making it difficult to `impl RunnableConfig` for all of them because it lives in a separate crate. This exposes the `register_probes_and_metrics_handler` so that we can call it without directly using a `RunnableConfig`