### PR TITLE
Add license information to the crates.

### DIFF
--- a/rust/instrumented-channel/Cargo.toml
+++ b/rust/instrumented-channel/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "instrumented-channel"
 version = "0.1.0"
-edition = "2021"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 delegate = { workspace = true }

--- a/rust/sdk-examples/Cargo.toml
+++ b/rust/sdk-examples/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "sdk-examples"
 version = "0.1.0"
-edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 ahash = { workspace = true }

--- a/rust/sdk/Cargo.toml
+++ b/rust/sdk/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "aptos-indexer-processor-sdk"
 version = "0.1.0"
-edition = "2021"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
* Aptos-core has strict license check. 