### PR TITLE
Change generic to T instead of Vec<T>

### DIFF
--- a/rust/sdk-examples/src/common_steps/latest_processed_version_tracker.rs
+++ b/rust/sdk-examples/src/common_steps/latest_processed_version_tracker.rs
@@ -13,6 +13,7 @@ use aptos_indexer_processor_sdk::{
 };
 use async_trait::async_trait;
 use diesel::{upsert::excluded, ExpressionMethods};
+use std::marker::PhantomData;
 
 const UPDATE_PROCESSOR_STATUS_SECS: u64 = 1;
 
@@ -26,9 +27,10 @@ where
     // Next version to process that we expect.
     next_version: u64,
     // Last successful batch of sequentially processed transactions. Includes metadata to write to storage.
-    last_success_batch: Option<TransactionContext<T>>,
+    last_success_batch: Option<TransactionContext<()>>,
     // Tracks all the versions that have been processed out of order.
-    seen_versions: AHashMap<u64, TransactionContext<T>>,
+    seen_versions: AHashMap<u64, TransactionContext<()>>,
+    _marker: PhantomData<T>,
 }
 
 impl<T> LatestVersionProcessedTracker<T>
@@ -53,10 +55,11 @@ where
             next_version: starting_version,
             last_success_batch: None,
             seen_versions: AHashMap::new(),
+            _marker: PhantomData,
         })
     }
 
-    fn update_last_success_batch(&mut self, current_batch: TransactionContext<T>) {
+    fn update_last_success_batch(&mut self, current_batch: TransactionContext<()>) {
         let mut new_prev_batch = current_batch;
         // While there are batches in seen_versions that are in order, update the new_prev_batch to the next batch.
         while let Some(next_version) = self.seen_versions.remove(&(new_prev_batch.end_version + 1))
@@ -125,7 +128,7 @@ where
             );
             self.seen_versions
                 .insert(current_batch.start_version, TransactionContext {
-                    data: vec![], // No data is needed for tracking. This is to avoid clone.
+                    data: (), // No data is needed for tracking. This is to avoid clone.
                     start_version: current_batch.start_version,
                     end_version: current_batch.end_version,
                     start_transaction_timestamp: current_batch.start_transaction_timestamp.clone(),
@@ -136,7 +139,7 @@ where
             tracing::debug!("No gap detected");
             // If the current_batch is the next expected version, update the last success batch
             self.update_last_success_batch(TransactionContext {
-                data: vec![], // No data is needed for tracking. This is to avoid clone.
+                data: (), // No data is needed for tracking. This is to avoid clone.
                 start_version: current_batch.start_version,
                 end_version: current_batch.end_version,
                 start_transaction_timestamp: current_batch.start_transaction_timestamp.clone(),

--- a/rust/sdk-examples/src/processors/events/events_extractor.rs
+++ b/rust/sdk-examples/src/processors/events/events_extractor.rs
@@ -16,14 +16,14 @@ where
 
 #[async_trait]
 impl Processable for EventsExtractor {
-    type Input = Transaction;
-    type Output = EventModel;
+    type Input = Vec<Transaction>;
+    type Output = Vec<EventModel>;
     type RunType = AsyncRunType;
 
     async fn process(
         &mut self,
-        item: TransactionContext<Transaction>,
-    ) -> Result<Option<TransactionContext<EventModel>>, ProcessorError> {
+        item: TransactionContext<Vec<Transaction>>,
+    ) -> Result<Option<TransactionContext<Vec<EventModel>>>, ProcessorError> {
         let events = item
             .data
             .par_iter()

--- a/rust/sdk-examples/src/processors/events/events_storer.rs
+++ b/rust/sdk-examples/src/processors/events/events_storer.rs
@@ -53,14 +53,14 @@ fn insert_events_query(
 
 #[async_trait]
 impl Processable for EventsStorer {
-    type Input = EventModel;
-    type Output = EventModel;
+    type Input = Vec<EventModel>;
+    type Output = Vec<EventModel>;
     type RunType = AsyncRunType;
 
     async fn process(
         &mut self,
-        events: TransactionContext<EventModel>,
-    ) -> Result<Option<TransactionContext<EventModel>>, ProcessorError> {
+        events: TransactionContext<Vec<EventModel>>,
+    ) -> Result<Option<TransactionContext<Vec<EventModel>>>, ProcessorError> {
         let per_table_chunk_sizes: AHashMap<String, usize> = AHashMap::new();
         let execute_res = execute_in_chunks(
             self.conn_pool.clone(),

--- a/rust/sdk/src/common_steps/arcify_step.rs
+++ b/rust/sdk/src/common_steps/arcify_step.rs
@@ -31,14 +31,14 @@ impl<T> Processable for ArcifyStep<T>
 where
     T: Send + Sync + 'static,
 {
-    type Input = T;
-    type Output = Arc<T>;
+    type Input = Vec<T>;
+    type Output = Vec<Arc<T>>;
     type RunType = AsyncRunType;
 
     async fn process(
         &mut self,
-        item: TransactionContext<T>,
-    ) -> Result<Option<TransactionContext<Arc<T>>>, ProcessorError> {
+        item: TransactionContext<Vec<T>>,
+    ) -> Result<Option<TransactionContext<Vec<Arc<T>>>>, ProcessorError> {
         Ok(Some(TransactionContext {
             data: item.data.into_iter().map(Arc::new).collect(),
             start_version: item.start_version,
@@ -65,7 +65,7 @@ where
 mod tests {
     use super::*;
 
-    fn generate_transaction_context() -> TransactionContext<usize> {
+    fn generate_transaction_context() -> TransactionContext<Vec<usize>> {
         TransactionContext {
             data: vec![1, 2, 3],
             start_version: 0,

--- a/rust/sdk/src/common_steps/transaction_stream_step.rs
+++ b/rust/sdk/src/common_steps/transaction_stream_step.rs
@@ -14,6 +14,9 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
+// TransactionStreamStep is establishes a gRPC connection with Transaction Stream
+// fetches transactions, and outputs them for processing. It also handles reconnections with retries.
+// This is usually the initial step in a processor.
 pub struct TransactionStreamStep
 where
     Self: Sized + Send + 'static,
@@ -49,6 +52,7 @@ where
     Self: Sized + Send + 'static,
 {
     type Input = ();
+    // The TransactionStreamStep will output a batch of transactions for processing
     type Output = Vec<Transaction>;
     type RunType = PollableAsyncRunType;
 

--- a/rust/sdk/src/common_steps/transaction_stream_step.rs
+++ b/rust/sdk/src/common_steps/transaction_stream_step.rs
@@ -49,13 +49,13 @@ where
     Self: Sized + Send + 'static,
 {
     type Input = ();
-    type Output = Transaction;
+    type Output = Vec<Transaction>;
     type RunType = PollableAsyncRunType;
 
     async fn process(
         &mut self,
         _item: TransactionContext<()>,
-    ) -> Result<Option<TransactionContext<Transaction>>, ProcessorError> {
+    ) -> Result<Option<TransactionContext<Vec<Transaction>>>, ProcessorError> {
         Ok(None)
     }
 }
@@ -71,7 +71,7 @@ where
 
     async fn poll(
         &mut self,
-    ) -> Result<Option<Vec<TransactionContext<Transaction>>>, ProcessorError> {
+    ) -> Result<Option<Vec<TransactionContext<Vec<Transaction>>>>, ProcessorError> {
         let txn_pb_response_res = self
             .transaction_stream
             .lock()
@@ -156,12 +156,12 @@ mock! {
     where Self: Sized + Send + 'static,
     {
         type Input = ();
-        type Output = Transaction;
+        type Output = Vec<Transaction>;
         type RunType = PollableAsyncRunType;
 
         async fn init(&mut self);
 
-        async fn process(&mut self, _item: TransactionContext<()> ) -> Result<Option<TransactionContext<Transaction>>, ProcessorError>;
+        async fn process(&mut self, _item: TransactionContext<()> ) -> Result<Option<TransactionContext<Vec<Transaction>>>, ProcessorError>;
     }
 
     #[async_trait]
@@ -183,7 +183,7 @@ mock! {
         //         size_in_bytes: 10,
         //     }])
         // }
-        async fn poll(&mut self) -> Result<Option<Vec<TransactionContext<Transaction>>>, ProcessorError>;
+        async fn poll(&mut self) -> Result<Option<Vec<TransactionContext<Vec<Transaction>>>>, ProcessorError>;
 
         async fn should_continue_polling(&mut self) -> bool;
     }

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -50,14 +50,14 @@ mod tests {
 
     #[async_trait]
     impl Processable for TestStep {
-        type Input = usize;
-        type Output = TestStruct;
+        type Input = Vec<usize>;
+        type Output = Vec<TestStruct>;
         type RunType = ();
 
         async fn process(
             &mut self,
-            item: TransactionContext<usize>,
-        ) -> Result<Option<TransactionContext<TestStruct>>, ProcessorError> {
+            item: TransactionContext<Vec<usize>>,
+        ) -> Result<Option<TransactionContext<Vec<TestStruct>>>, ProcessorError> {
             let processed = item.data.into_iter().map(|i| TestStruct { i }).collect();
             Ok(Some(TransactionContext {
                 data: processed,
@@ -81,7 +81,7 @@ mod tests {
         );
 
         // Create a timed buffer that outputs the input after 1 second
-        let timed_buffer_step = TimedBufferStep::<usize>::new(Duration::from_millis(200));
+        let timed_buffer_step = TimedBufferStep::<Vec<usize>>::new(Duration::from_millis(200));
         let first_step = timed_buffer_step;
 
         let second_step = TestStep;

--- a/rust/sdk/src/types/transaction_context.rs
+++ b/rust/sdk/src/types/transaction_context.rs
@@ -7,7 +7,7 @@ use aptos_indexer_transaction_stream::utils::timestamp_to_unixtime;
 /// data originated from. The metadata is used for metrics and logging purposes.
 #[derive(Clone, Default)]
 pub struct TransactionContext<T> {
-    pub data: Vec<T>,
+    pub data: T,
 
     // Metadata about the transactions that the data is associated with
     pub start_version: u64,


### PR DESCRIPTION
## Description 
The generic `T` represents the data that is extracted and associated with a batch of transactions. The SDK requires that each `process` returns a `Vec<T>` but that is too restrictive and processors end up having to define a lot of empty vec's. 

An example is the fungible asset processor where the extracted data is actually of type `(Vec<...>, Vec<...>, ...)`. 

This PR changes the generic to `T`. If a step expects input as a `Vec<T>`, you will need to change the generics from `T` to `Vec<T>`. 

## Testing 
lint, run the events processor