### PR TITLE
Ignore Needless Return Complaints in Clippy

### DIFF
--- a/rust/instrumented-channel/src/lib.rs
+++ b/rust/instrumented-channel/src/lib.rs
@@ -179,6 +179,7 @@ mod tests {
         String::from_utf8(buffer).unwrap()
     }
     #[tokio::test]
+    #[allow(clippy::needless_return)]
     async fn test_instrumented_channel() {
         let (sender, receiver) = instrumented_bounded_channel("my_channel", 10);
         sender.send(42).await.unwrap();

--- a/rust/sample/src/lib.rs
+++ b/rust/sample/src/lib.rs
@@ -21,7 +21,6 @@ use std::{
 /// // Sampled based on time passed, log at most once a minute
 /// sample!(SampleRate::Duration(Duration::from_secs(60)), info!("Long log"));
 /// ```
-
 /// The rate at which a `sample!` macro will run it's given function
 #[derive(Debug)]
 pub enum SampleRate {

--- a/rust/sdk/src/common_steps/arcify_step.rs
+++ b/rust/sdk/src/common_steps/arcify_step.rs
@@ -77,6 +77,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::needless_return)]
     async fn test_arcify_step_process() {
         let mut step = ArcifyStep::<usize>::new();
         let input = generate_transaction_context();
@@ -89,6 +90,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::needless_return)]
     async fn test_arcify_strong_count() {
         let mut step = ArcifyStep::<usize>::new();
         let input = generate_transaction_context();
@@ -104,6 +106,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::needless_return)]
     async fn test_arcify_ptr_eq() {
         let mut step = ArcifyStep::<usize>::new();
         let input = generate_transaction_context();

--- a/rust/sdk/src/common_steps/transaction_stream_step.rs
+++ b/rust/sdk/src/common_steps/transaction_stream_step.rs
@@ -205,6 +205,7 @@ mod tests {
     use std::time::Duration;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::needless_return)]
     async fn test_transaction_stream() {
         let mut mock_transaction_stream = MockTransactionStreamStep::new();
         // Testing framework can provide mocked transactions here

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -71,6 +71,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::needless_return)]
     async fn test_connect_two_steps() {
         let (input_sender, input_receiver) = instrumented_bounded_channel("input", 1);
 
@@ -146,6 +147,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::needless_return)]
     async fn test_fanin() {
         let (input_sender, input_receiver) = instrumented_bounded_channel("input", 1);
 


### PR DESCRIPTION
Ignore false positives introduced by recent clippy update in nightly. See this thread: https://github.com/rust-lang/rust-clippy/issues/13458