### PR TITLE
Create generic order step to order by transaction starting version

### DIFF
--- a/aptos-indexer-processors-sdk/Cargo.lock
+++ b/aptos-indexer-processors-sdk/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -119,6 +120,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 name = "aptos-indexer-processor-sdk"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "aptos-indexer-transaction-stream",
  "aptos-protos",

--- a/aptos-indexer-processors-sdk/sdk/Cargo.toml
+++ b/aptos-indexer-processors-sdk/sdk/Cargo.toml
@@ -12,6 +12,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 anyhow = { workspace = true }
 aptos-indexer-transaction-stream = { workspace = true }
 aptos-protos = { workspace = true }

--- a/aptos-indexer-processors-sdk/sdk/src/common_steps/mod.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/common_steps/mod.rs
@@ -5,5 +5,6 @@ pub mod transaction_stream_step;
 
 // Re-export the steps
 pub use arcify_step::ArcifyStep;
+pub use order_by_version_step::OrderByVersionStep;
 pub use timed_buffer_step::TimedBufferStep;
 pub use transaction_stream_step::TransactionStreamStep;

--- a/aptos-indexer-processors-sdk/sdk/src/common_steps/mod.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/common_steps/mod.rs
@@ -1,4 +1,5 @@
 pub mod arcify_step;
+pub mod order_by_version_step;
 pub mod timed_buffer_step;
 pub mod transaction_stream_step;
 

--- a/aptos-indexer-processors-sdk/sdk/src/common_steps/order_by_version_step.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/common_steps/order_by_version_step.rs
@@ -1,0 +1,115 @@
+use crate::{
+    traits::{
+        pollable_async_step::PollableAsyncRunType, NamedStep, PollableAsyncStep, Processable,
+    },
+    types::transaction_context::TransactionContext,
+    utils::errors::ProcessorError,
+};
+use ahash::AHashMap;
+use anyhow::Result;
+use async_trait::async_trait;
+use std::time::Duration;
+
+pub struct OrderByStartingVersionStep<Input>
+where
+    Self: Sized + Send + 'static,
+    Input: Send + 'static,
+{
+    pub ordered_versions: Vec<TransactionContext<Input>>,
+    pub unordered_versions: AHashMap<u64, TransactionContext<Input>>,
+    pub expected_next_version: u64,
+    // pub versions: BTreeSet<TransactionContext<Input>>,
+    // Duration to poll and return the ordered versions
+    pub poll_interval: Duration,
+}
+
+impl<Input> OrderByStartingVersionStep<Input>
+where
+    Self: Sized + Send + 'static,
+    Input: Send + 'static,
+{
+    pub fn new(starting_version: u64, poll_interval: Duration) -> Self {
+        Self {
+            ordered_versions: Vec::new(),
+            unordered_versions: AHashMap::new(),
+            expected_next_version: starting_version,
+            poll_interval,
+        }
+    }
+
+    fn update_ordered_versions(&mut self) {
+        // While there are batches in unordered_versions that are in order, add them to ordered_versions
+        while let Some(batch) = self
+            .unordered_versions
+            .remove(&(self.expected_next_version))
+        {
+            self.expected_next_version = batch.metadata.end_version + 1;
+            self.ordered_versions.push(batch);
+        }
+    }
+}
+
+#[async_trait]
+impl<Input> Processable for OrderByStartingVersionStep<Input>
+where
+    Input: Send + Sync + 'static,
+{
+    type Input = Input;
+    type Output = Input;
+    type RunType = PollableAsyncRunType;
+
+    async fn process(
+        &mut self,
+        current_batch: TransactionContext<Input>,
+    ) -> Result<Option<TransactionContext<Input>>, ProcessorError> {
+        // If there's a gap in the expected_next_version and current_version
+        // ave the current_version to unordered_versions for later processing.
+        if self.expected_next_version != current_batch.metadata.start_version {
+            tracing::debug!(
+                next_version = self.expected_next_version,
+                step = self.name(),
+                "Gap detected starting from version: {}",
+                current_batch.metadata.start_version
+            );
+            self.unordered_versions
+                .insert(current_batch.metadata.start_version, current_batch);
+        } else {
+            tracing::debug!("No gap detected");
+            self.expected_next_version = current_batch.metadata.end_version + 1;
+            self.ordered_versions.push(current_batch);
+
+            // If the current_versions is the expected_next_version, update the ordered_versions
+            self.update_ordered_versions();
+        }
+        // Pass through
+        Ok(None) // No immediate output
+    }
+
+    // Once polling ends, release the remaining ordered items in buffer
+    async fn cleanup(
+        &mut self,
+    ) -> Result<Option<Vec<TransactionContext<Self::Output>>>, ProcessorError> {
+        Ok(Some(std::mem::take(&mut self.ordered_versions)))
+    }
+}
+
+#[async_trait]
+impl<Input: Send + Sync + 'static> PollableAsyncStep for OrderByStartingVersionStep<Input> {
+    fn poll_interval(&self) -> Duration {
+        self.poll_interval
+    }
+
+    async fn poll(&mut self) -> Result<Option<Vec<TransactionContext<Input>>>, ProcessorError> {
+        Ok(Some(std::mem::take(&mut self.ordered_versions)))
+    }
+}
+
+impl<Input: Send + 'static> NamedStep for OrderByStartingVersionStep<Input> {
+    // TODO: oncecell this somehow? Likely in wrapper struct...
+    fn name(&self) -> String {
+        format!(
+            "OrderByStartingVersionStep: {}",
+            std::any::type_name::<Input>()
+        )
+    }
+}

--- a/aptos-indexer-processors-sdk/sdk/src/common_steps/order_by_version_step.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/common_steps/order_by_version_step.rs
@@ -148,6 +148,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[allow(clippy::needless_return)]
     async fn test_order_step() {
         // Setup
         let (input_sender, input_receiver) = instrumented_bounded_channel("input", 1);
@@ -171,13 +172,13 @@ mod tests {
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        for i in 0..2 {
+        for ordered_transaction_context in ordered_transaction_contexts {
             let result = receive_with_timeout(&mut output_receiver, 100)
                 .await
                 .unwrap();
             assert_eq!(
                 result.metadata.start_version,
-                ordered_transaction_contexts[i].metadata.start_version
+                ordered_transaction_context.metadata.start_version
             );
         }
     }

--- a/aptos-indexer-processors-sdk/sdk/src/types/transaction_context.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/types/transaction_context.rs
@@ -24,6 +24,28 @@ impl<T> TransactionContext<T> {
     }
 }
 
+impl<T> Ord for TransactionContext<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.metadata
+            .start_version
+            .cmp(&other.metadata.start_version)
+    }
+}
+
+impl<T> PartialOrd for TransactionContext<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Eq for TransactionContext<T> {}
+
+impl<T> PartialEq for TransactionContext<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.metadata.start_version == other.metadata.start_version
+    }
+}
+
 // Metadata about a batch of transactions
 #[derive(Clone, Default)]
 pub struct TransactionMetadata {


### PR DESCRIPTION
## Description

This change introduces a new `OrderByVersionStep` to support use cases where transaction batches need to be in the correct order. An example of a usage is in latest version tracking. 

Updates in this PR include:

- Added `OrderByVersionStep` to handle out-of-order transaction batches. This ensures that the output transaction batches are ordered by their starting version. It achieves this by collecting unordered batches, sorting them, and then releasing them in the correct order.

## Testing

cargo test