### PR TITLE
Remove reference to tracker_name in VersionTracker

### DIFF
--- a/aptos-indexer-processors-sdk/sdk/src/common_steps/version_tracker_step.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/common_steps/version_tracker_step.rs
@@ -13,7 +13,7 @@ pub const DEFAULT_UPDATE_PROCESSOR_STATUS_SECS: u64 = 1;
 /// The `ProcessorStatusSaver` trait object should be implemented in order to save the latest successfully
 /// processed transaction versino to storage. I.e., persisting the `processor_status` to storage.
 #[async_trait]
-pub trait ProcessorStatusSaver: Send + 'static {
+pub trait ProcessorStatusSaver {
     // T represents the transaction type that the processor is tracking.
     async fn save_processor_status(
         &self,

--- a/aptos-indexer-processors-sdk/sdk/src/common_steps/version_tracker_step.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/common_steps/version_tracker_step.rs
@@ -13,7 +13,7 @@ pub const DEFAULT_UPDATE_PROCESSOR_STATUS_SECS: u64 = 1;
 /// The `ProcessorStatusSaver` trait object should be implemented in order to save the latest successfully
 /// processed transaction versino to storage. I.e., persisting the `processor_status` to storage.
 #[async_trait]
-pub trait ProcessorStatusSaver {
+pub trait ProcessorStatusSaver: Send + 'static {
     // T represents the transaction type that the processor is tracking.
     async fn save_processor_status(
         &self,


### PR DESCRIPTION
## Purpose
Remove `tracker_name` in VersionTracker struct as its not needed. This decouples the interface from the implementation. See usage [here](https://github.com/aptos-labs/aptos-indexer-processor-example/pull/6). 