### PR TITLE
Add latency metrics to SDK

### DIFF
--- a/aptos-indexer-processors-sdk/sdk/src/traits/async_step.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/traits/async_step.rs
@@ -117,6 +117,9 @@ where
                             step_name: step.name(),
                         })
                         .latest_processed_version(output_with_context.metadata.end_version)
+                        .processed_transaction_latency(
+                            output_with_context.get_transaction_latency(),
+                        )
                         .latest_transaction_timestamp(
                             output_with_context.get_start_transaction_timestamp_unix(),
                         )

--- a/aptos-indexer-processors-sdk/sdk/src/traits/pollable_async_step.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/traits/pollable_async_step.rs
@@ -161,6 +161,9 @@ where
                                     .latest_polled_transaction_timestamp(
                                         output_with_context.get_start_transaction_timestamp_unix(),
                                     )
+                                    .polled_transaction_latency(
+                                        output_with_context.get_transaction_latency(),
+                                    )
                                     .num_polled_transactions_count(
                                         output_with_context.get_num_transactions(),
                                     )
@@ -238,6 +241,9 @@ where
                             .latest_transaction_timestamp(
                                 output_with_context.get_start_transaction_timestamp_unix(),
                             )
+                            .polled_transaction_latency(
+                                output_with_context.get_transaction_latency(),
+                            )
                             .num_transactions_processed_count(
                                 output_with_context.get_num_transactions(),
                             )
@@ -299,6 +305,9 @@ where
                             .latest_polled_version(output_with_context.metadata.end_version)
                             .latest_polled_transaction_timestamp(
                                 output_with_context.get_start_transaction_timestamp_unix(),
+                            )
+                            .polled_transaction_latency(
+                                output_with_context.get_transaction_latency(),
                             )
                             .num_polled_transactions_count(
                                 output_with_context.get_num_transactions(),

--- a/aptos-indexer-processors-sdk/sdk/src/types/transaction_context.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/types/transaction_context.rs
@@ -1,5 +1,5 @@
+use crate::utils::time::time_diff_since_pb_timestamp_in_secs;
 use aptos_indexer_transaction_stream::utils::timestamp_to_unixtime;
-
 /// Contains processed data and associated transaction metadata.
 ///
 /// The processed data is extracted from transactions and the
@@ -21,6 +21,13 @@ impl<T> TransactionContext<T> {
             .start_transaction_timestamp
             .as_ref()
             .map(timestamp_to_unixtime)
+    }
+
+    pub fn get_transaction_latency(&self) -> Option<f64> {
+        self.metadata
+            .start_transaction_timestamp
+            .as_ref()
+            .map(time_diff_since_pb_timestamp_in_secs)
     }
 }
 

--- a/aptos-indexer-processors-sdk/sdk/src/utils/step_metrics.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/utils/step_metrics.rs
@@ -24,8 +24,11 @@ pub fn init_step_metrics_registry(registry: &mut Registry) {
     );
 
     registry.register(
-        format!("{}_{}", METRICS_PREFIX, "processed_transaction_latency"),
-        "Latency of the polled transactions, computed by (txn timestamp - current time)",
+        format!(
+            "{}_{}",
+            METRICS_PREFIX, "processed_transaction_latency_secs"
+        ),
+        "Latency of the processed transactions, computed by (txn timestamp - current time)",
         PROCESSED_TRANSACTION_LATENCY.clone(),
     );
 
@@ -70,7 +73,7 @@ pub fn init_step_metrics_registry(registry: &mut Registry) {
     );
 
     registry.register(
-        format!("{}_{}", METRICS_PREFIX, "polled_transaction_latency"),
+        format!("{}_{}", METRICS_PREFIX, "polled_transaction_latency_secs"),
         "Latency of the polled transactions, computed by (txn timestamp - current time)",
         POLLED_TRANSACTION_LATENCY.clone(),
     );

--- a/aptos-indexer-processors-sdk/sdk/src/utils/step_metrics.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/utils/step_metrics.rs
@@ -159,7 +159,7 @@ pub struct StepMetrics {
     latest_processed_version: Option<u64>,
     #[builder(default)]
     latest_transaction_timestamp: Option<f64>,
-    #[builder(default, setter(strip_option))]
+    #[builder(default)]
     processed_transaction_latency: Option<f64>,
     #[builder(default, setter(strip_option))]
     num_transactions_processed_count: Option<u64>,
@@ -173,7 +173,7 @@ pub struct StepMetrics {
     latest_polled_version: Option<u64>,
     #[builder(default)]
     latest_polled_transaction_timestamp: Option<f64>,
-    #[builder(default, setter(strip_option))]
+    #[builder(default)]
     polled_transaction_latency: Option<f64>,
     #[builder(default, setter(strip_option))]
     num_polled_transactions_count: Option<u64>,

--- a/aptos-indexer-processors-sdk/sdk/src/utils/step_metrics.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/utils/step_metrics.rs
@@ -24,6 +24,12 @@ pub fn init_step_metrics_registry(registry: &mut Registry) {
     );
 
     registry.register(
+        format!("{}_{}", METRICS_PREFIX, "processed_transaction_latency"),
+        "Latency of the polled transactions, computed by (txn timestamp - current time)",
+        PROCESSED_TRANSACTION_LATENCY.clone(),
+    );
+
+    registry.register(
         format!("{}_{}", METRICS_PREFIX, "num_transactions_processed_count"),
         "Number of transactions processed",
         NUM_TRANSACTIONS_PROCESSED_COUNT.clone(),
@@ -64,6 +70,12 @@ pub fn init_step_metrics_registry(registry: &mut Registry) {
     );
 
     registry.register(
+        format!("{}_{}", METRICS_PREFIX, "polled_transaction_latency"),
+        "Latency of the polled transactions, computed by (txn timestamp - current time)",
+        POLLED_TRANSACTION_LATENCY.clone(),
+    );
+
+    registry.register(
         format!("{}_{}", METRICS_PREFIX, "num_polled_transactions_count"),
         "Number of transactions polled",
         NUM_POLLED_TRANSACTIONS_COUNT.clone(),
@@ -101,6 +113,9 @@ pub static LATEST_PROCESSED_TRANSACTION_TIMESTAMP: Lazy<
     Family<StepMetricLabels, Gauge<f64, AtomicU64>>,
 > = Lazy::new(Family::<StepMetricLabels, Gauge<f64, AtomicU64>>::default);
 
+pub static PROCESSED_TRANSACTION_LATENCY: Lazy<Family<StepMetricLabels, Gauge<f64, AtomicU64>>> =
+    Lazy::new(Family::<StepMetricLabels, Gauge<f64, AtomicU64>>::default);
+
 pub static NUM_TRANSACTIONS_PROCESSED_COUNT: Lazy<Family<StepMetricLabels, Counter>> =
     Lazy::new(Family::<StepMetricLabels, Counter>::default);
 
@@ -120,6 +135,9 @@ pub static LATEST_POLLED_VERSION: Lazy<Family<StepMetricLabels, Gauge>> =
 pub static LATEST_POLLED_TRANSACTION_TIMESTAMP: Lazy<
     Family<StepMetricLabels, Gauge<f64, AtomicU64>>,
 > = Lazy::new(Family::<StepMetricLabels, Gauge<f64, AtomicU64>>::default);
+
+pub static POLLED_TRANSACTION_LATENCY: Lazy<Family<StepMetricLabels, Gauge<f64, AtomicU64>>> =
+    Lazy::new(Family::<StepMetricLabels, Gauge<f64, AtomicU64>>::default);
 
 pub static NUM_POLLED_TRANSACTIONS_COUNT: Lazy<Family<StepMetricLabels, Counter>> =
     Lazy::new(Family::<StepMetricLabels, Counter>::default);
@@ -142,6 +160,8 @@ pub struct StepMetrics {
     #[builder(default)]
     latest_transaction_timestamp: Option<f64>,
     #[builder(default, setter(strip_option))]
+    processed_transaction_latency: Option<f64>,
+    #[builder(default, setter(strip_option))]
     num_transactions_processed_count: Option<u64>,
     #[builder(default, setter(strip_option))]
     processing_duration_in_secs: Option<f64>,
@@ -153,6 +173,8 @@ pub struct StepMetrics {
     latest_polled_version: Option<u64>,
     #[builder(default)]
     latest_polled_transaction_timestamp: Option<f64>,
+    #[builder(default, setter(strip_option))]
+    polled_transaction_latency: Option<f64>,
     #[builder(default, setter(strip_option))]
     num_polled_transactions_count: Option<u64>,
     #[builder(default, setter(strip_option))]
@@ -173,6 +195,11 @@ impl StepMetrics {
             LATEST_PROCESSED_TRANSACTION_TIMESTAMP
                 .get_or_create(&self.labels)
                 .set(timestamp);
+        }
+        if let Some(processed_latency) = self.processed_transaction_latency {
+            PROCESSED_TRANSACTION_LATENCY
+                .get_or_create(&self.labels)
+                .set(processed_latency);
         }
         if let Some(count) = self.num_transactions_processed_count {
             NUM_TRANSACTIONS_PROCESSED_COUNT
@@ -200,6 +227,11 @@ impl StepMetrics {
             LATEST_POLLED_TRANSACTION_TIMESTAMP
                 .get_or_create(&self.labels)
                 .set(timestamp);
+        }
+        if let Some(polled_latency) = self.polled_transaction_latency {
+            POLLED_TRANSACTION_LATENCY
+                .get_or_create(&self.labels)
+                .set(polled_latency);
         }
         if let Some(count) = self.num_polled_transactions_count {
             NUM_POLLED_TRANSACTIONS_COUNT


### PR DESCRIPTION
## Description

- Add transaction latency metrics for AsyncStep  and PollableAsyncStep. It is calculated using (current time - txn timestamp) 
- This will be used in Forge tests to track total processor latency

## Testing
Tested with example processor

![Screenshot 2024-10-10 at 6.14.15 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vIwavW9noSx0eb70aDLz/e86141bf-6400-4429-b666-746eec18d870.png)

