### PR TITLE
move file generation function out of sdk test context

### DIFF
--- a/aptos-indexer-processors-sdk/testing-framework/src/cli_parser.rs
+++ b/aptos-indexer-processors-sdk/testing-framework/src/cli_parser.rs
@@ -1,53 +1,50 @@
-#[cfg(test)]
-pub mod tests {
-    use once_cell::sync::Lazy;
-    use std::sync::Mutex;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
 
-    #[derive(Debug, Clone)]
-    pub struct TestArgs {
-        pub generate_output: bool,
-        pub output_path: Option<String>,
-    }
+#[derive(Debug, Clone)]
+pub struct TestArgs {
+    pub generate_output: bool,
+    pub output_path: Option<String>,
+}
 
-    // Define a global static to store the parsed arguments
-    static TEST_CONFIG: Lazy<Mutex<TestArgs>> = Lazy::new(|| {
-        let args = parse_test_args();
-        Mutex::new(args)
-    });
+// Define a global static to store the parsed arguments
+static TEST_CONFIG: Lazy<Mutex<TestArgs>> = Lazy::new(|| {
+    let args = parse_test_args();
+    Mutex::new(args)
+});
 
-    // Function to fetch global test args
-    pub fn get_test_config() -> (bool, Option<String>) {
-        let test_args = TEST_CONFIG.lock().unwrap().clone();
-        (test_args.generate_output, test_args.output_path)
-    }
+// Function to fetch global test args
+pub fn get_test_config() -> (bool, Option<String>) {
+    let test_args = TEST_CONFIG.lock().unwrap().clone();
+    (test_args.generate_output, test_args.output_path)
+}
 
-    pub fn parse_test_args() -> TestArgs {
-        let raw_args: Vec<String> = std::env::args().collect();
+pub fn parse_test_args() -> TestArgs {
+    let raw_args: Vec<String> = std::env::args().collect();
 
-        // Find the "--" separator (if it exists)
-        let clap_args_position = raw_args.iter().position(|arg| arg == "--");
+    // Find the "--" separator (if it exists)
+    let clap_args_position = raw_args.iter().position(|arg| arg == "--");
 
-        // Only pass the arguments that come after "--", if it exists
-        let custom_args: Vec<String> = match clap_args_position {
-            Some(position) => raw_args[position + 1..].to_vec(), // Slice after `--`
-            None => Vec::new(), // If no `--` is found, treat as no custom args
-        };
+    // Only pass the arguments that come after "--", if it exists
+    let custom_args: Vec<String> = match clap_args_position {
+        Some(position) => raw_args[position + 1..].to_vec(), // Slice after `--`
+        None => Vec::new(), // If no `--` is found, treat as no custom args
+    };
 
-        // Manually parse the "--generate-output" flag
-        let generate_output_flag = custom_args.contains(&"--generate-output".to_string());
+    // Manually parse the "--generate-output" flag
+    let generate_output_flag = custom_args.contains(&"--generate-output".to_string());
 
-        // Manually parse the "--output-path" flag and get its associated value
-        let output_path = custom_args
-            .windows(2)
-            .find(|args| args[0] == "--output-path")
-            .map(|args| args[1].clone());
+    // Manually parse the "--output-path" flag and get its associated value
+    let output_path = custom_args
+        .windows(2)
+        .find(|args| args[0] == "--output-path")
+        .map(|args| args[1].clone());
 
-        println!("Parsed generate_output_flag: {}", generate_output_flag);
-        println!("Parsed output_path: {:?}", output_path);
+    println!("Parsed generate_output_flag: {}", generate_output_flag);
+    println!("Parsed output_path: {:?}", output_path);
 
-        TestArgs {
-            generate_output: generate_output_flag,
-            output_path,
-        }
+    TestArgs {
+        generate_output: generate_output_flag,
+        output_path,
     }
 }

--- a/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
+++ b/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
@@ -36,7 +36,7 @@ impl SdkTestContext {
                     anyhow::anyhow!(
                         "Failed to parse transaction at index {}: {}",
                         idx,
-                        Self::format_serde_error(err)
+                        format_serde_error(err)
                     )
                 })
             })
@@ -115,9 +115,9 @@ impl SdkTestContext {
 
             // Iterate over each table's data in the HashMap and generate an output file
             for (table_name, table_data) in db_values.iter_mut() {
-                Self::remove_inserted_at(table_data);
+                remove_inserted_at(table_data);
 
-                self.generate_output_file(
+                generate_output_file(
                     processor.name(),
                     table_name,
                     &format!("{}", txn_version),
@@ -174,65 +174,63 @@ impl SdkTestContext {
             indexer_grpc_response_item_timeout_secs: 60,
         }
     }
+}
 
-    /// Helper function to format serde_json errors for better readability.
-    fn format_serde_error(err: SerdeError) -> String {
-        match err.classify() {
-            serde_json::error::Category::Io => format!("I/O error: {}", err),
-            serde_json::error::Category::Syntax => format!("Syntax error: {}", err),
-            serde_json::error::Category::Data => format!("Data error: {}", err),
-            serde_json::error::Category::Eof => format!("Unexpected end of input: {}", err),
-        }
+/// Helper function to format serde_json errors for better readability.
+fn format_serde_error(err: SerdeError) -> String {
+    match err.classify() {
+        serde_json::error::Category::Io => format!("I/O error: {}", err),
+        serde_json::error::Category::Syntax => format!("Syntax error: {}", err),
+        serde_json::error::Category::Data => format!("Data error: {}", err),
+        serde_json::error::Category::Eof => format!("Unexpected end of input: {}", err),
     }
+}
 
-    // Helper function to construct the output file path with the table name
-    fn construct_file_path(
-        output_dir: &str,
-        processor_name: &str,
-        table_name: &str,
-        txn_version: &str,
-    ) -> PathBuf {
-        Path::new(output_dir)
-            .join(processor_name)
-            .join(txn_version)
-            .join(format!("{}.json", table_name)) // Including table_name in the format
+// Helper function to construct the output file path with the table name
+fn construct_file_path(
+    output_dir: &str,
+    processor_name: &str,
+    table_name: &str,
+    txn_version: &str,
+) -> PathBuf {
+    Path::new(output_dir)
+        .join(processor_name)
+        .join(txn_version)
+        .join(format!("{}.json", table_name)) // Including table_name in the format
+}
+
+// Helper function to ensure the directory exists
+fn ensure_directory_exists(path: &Path) -> anyhow::Result<()> {
+    if let Some(parent_dir) = path.parent() {
+        fs::create_dir_all(parent_dir).context("Failed to create directory")?;
     }
+    Ok(())
+}
 
-    // Helper function to ensure the directory exists
-    fn ensure_directory_exists(path: &Path) -> anyhow::Result<()> {
-        if let Some(parent_dir) = path.parent() {
-            fs::create_dir_all(parent_dir).context("Failed to create directory")?;
-        }
-        Ok(())
-    }
+// Helper function to generate output files for each table
+pub fn generate_output_file(
+    processor_name: &str,
+    table_name: &str,
+    txn_version: &str,
+    db_values: &serde_json::Value,
+    output_dir: String,
+) -> anyhow::Result<()> {
+    let file_path = construct_file_path(&output_dir, processor_name, table_name, txn_version); // Pass table_name here
 
-    // Helper function to generate output files for each table
-    pub fn generate_output_file(
-        &self,
-        processor_name: &str,
-        table_name: &str,
-        txn_version: &str,
-        db_values: &serde_json::Value,
-        output_dir: String,
-    ) -> anyhow::Result<()> {
-        let file_path =
-            Self::construct_file_path(&output_dir, processor_name, table_name, txn_version); // Pass table_name here
+    ensure_directory_exists(&file_path)?;
 
-        Self::ensure_directory_exists(&file_path)?;
+    fs::write(&file_path, to_string_pretty(db_values)?)
+        .context(format!("Failed to write file to {:?}", file_path))?;
+    println!("[TEST] Generated output file at: {}", file_path.display());
+    Ok(())
+}
 
-        fs::write(&file_path, to_string_pretty(db_values)?)
-            .context(format!("Failed to write file to {:?}", file_path))?;
-        println!("[TEST] Generated output file at: {}", file_path.display());
-        Ok(())
-    }
-
-    #[allow(dead_code)]
-    pub fn remove_inserted_at(value: &mut Value) {
-        if let Some(array) = value.as_array_mut() {
-            for item in array.iter_mut() {
-                if let Some(obj) = item.as_object_mut() {
-                    obj.remove("inserted_at");
-                }
+#[allow(dead_code)]
+pub fn remove_inserted_at(value: &mut Value) {
+    if let Some(array) = value.as_array_mut() {
+        for item in array.iter_mut() {
+            if let Some(obj) = item.as_object_mut() {
+                obj.remove("inserted_at");
             }
         }
     }


### PR DESCRIPTION
### Description
importing test cli was guarded by #[cfg(test)] 

```
error[E0432]: unresolved import `aptos_indexer_testing_framework::cli_parser::tests`
  --> integration-tests/src/diff_tests/all_tests.rs:21:21
   |
21 |         cli_parser::tests::get_test_config,
   |                     ^^^^^ could not find `tests` in `cli_parser`
   |
note: found an item that was configured out
  --> /Users/yuunlim/.cargo/git/checkouts/aptos-indexer-processor-sdk-2f3940a333c8389d/09acae7/aptos-indexer-processors-sdk/testing-framework/src/cli_parser.rs:2:9
   |
2  | pub mod tests {
   |         ^^^^^
note: the item is gated here
  --> /Users/yuunlim/.cargo/git/checkouts/aptos-indexer-processor-sdk-2f3940a333c8389d/09acae7/aptos-indexer-processors-sdk/testing-framework/src/cli_parser.rs:1:1
   |
1  | #[cfg(test)]
   | ^^^^^^^^^^^^

```

