### PR TITLE
abstract stream config setup

### DIFF
--- a/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
+++ b/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
@@ -172,7 +172,7 @@ impl SdkTestContext {
             indexer_grpc_data_service_address: Url::parse(&data_service_address)
                 .expect("Could not parse database url"),
             starting_version: Some(1),
-            request_ending_version: Some(1 + txn_count - 1),
+            request_ending_version: Some(txn_count),
             auth_token: "".to_string(),
             request_name_header: "sdk-testing".to_string(),
             indexer_grpc_http2_ping_interval_secs: 30,


### PR DESCRIPTION
Address comment here: https://github.com/aptos-labs/aptos-indexer-processors/pull/559 to abstract away the stream config setup function to not confuse users. They don't have to specify the starting_version to 1. 