### PR TITLE
update generate_outpu_file function to correctly strcuture output folder

### DIFF
--- a/aptos-indexer-processors-sdk/testing-framework/src/mock_grpc.rs
+++ b/aptos-indexer-processors-sdk/testing-framework/src/mock_grpc.rs
@@ -30,7 +30,6 @@ impl RawData for MockGrpcServer {
         let request = req.into_inner();
         let starting_version = request.starting_version.unwrap_or(0); // Default to 0 if starting_version is not provided
         let transactions_count = request.transactions_count.unwrap_or(1); // Default to 1 if transactions_count is not provided
-
         let mut collected_transactions = Vec::new();
 
         let mut transaction_map = HashMap::new();
@@ -47,7 +46,11 @@ impl RawData for MockGrpcServer {
             .collect();
         sorted_transactions.sort_by_key(|tx| tx.version);
 
-        collected_transactions.extend(sorted_transactions.into_iter().take(transactions_count as usize));
+        collected_transactions.extend(
+            sorted_transactions
+                .into_iter()
+                .take(transactions_count as usize),
+        );
 
         let result = if !collected_transactions.is_empty() {
             TransactionsResponse {
@@ -63,7 +66,6 @@ impl RawData for MockGrpcServer {
 
         let stream = futures::stream::iter(vec![Ok(result)]);
         Ok(Response::new(Box::pin(stream)))
-
     }
 }
 

--- a/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
+++ b/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
@@ -160,7 +160,7 @@ impl SdkTestContext {
         port
     }
 
-    pub fn create_transaction_stream_config(&self, starting_version: u64, txn_count: u64) -> TransactionStreamConfig {
+    pub fn create_transaction_stream_config(&self, starting_version: u64, ending_version: u64, txn_count: u64) -> TransactionStreamConfig {
         let data_service_address = format!(
             "http://localhost:{}",
             self.port.as_ref().expect("Port is not set")
@@ -169,7 +169,7 @@ impl SdkTestContext {
             indexer_grpc_data_service_address: Url::parse(&data_service_address)
                 .expect("Could not parse database url"),
             starting_version: Some(starting_version),
-            request_ending_version: Some(txn_count),
+            request_ending_version: Some(starting_version + txn_count - 1),
             auth_token: "".to_string(),
             request_name_header: "sdk-testing".to_string(),
             indexer_grpc_http2_ping_interval_secs: 30,

--- a/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
+++ b/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
@@ -160,10 +160,7 @@ impl SdkTestContext {
         port
     }
 
-    pub fn create_transaction_stream_config(
-        &self,
-        txn_count: u64,
-    ) -> TransactionStreamConfig {
+    pub fn create_transaction_stream_config(&self, starting_version: u64, txn_count: u64) -> TransactionStreamConfig {
         let data_service_address = format!(
             "http://localhost:{}",
             self.port.as_ref().expect("Port is not set")
@@ -171,7 +168,7 @@ impl SdkTestContext {
         TransactionStreamConfig {
             indexer_grpc_data_service_address: Url::parse(&data_service_address)
                 .expect("Could not parse database url"),
-            starting_version: Some(1),
+            starting_version: Some(starting_version),
             request_ending_version: Some(txn_count),
             auth_token: "".to_string(),
             request_name_header: "sdk-testing".to_string(),
@@ -226,9 +223,12 @@ pub fn generate_output_file(
     let file_path = match custom_file_name {
         Some(custom_name) => {
             // If custom_file_name is present, build the file path using it
-            PathBuf::from(&output_dir).join(processor_name).join(
-                format!("{}.json", custom_name), // Including table_name in the format
-            )
+            PathBuf::from(&output_dir)
+                .join(processor_name)
+                .join(custom_name)
+                .join(
+                    format!("{}.json", table_name),
+                )
         },
         None => {
             // Default case: use table_name and txn_version to construct file name


### PR DESCRIPTION
### Description
Fix folder structure to use support multiple table files per test case/processor 
![Screenshot 2024-10-21 at 12 13 30 PM](https://github.com/user-attachments/assets/e2a270b2-b723-47d5-a2c7-e3de699752ad)
