### PR TITLE
Improve SdkTestContext

### DIFF
--- a/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
+++ b/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
@@ -55,7 +55,7 @@ impl SdkTestContext {
             Err(e) => panic!("Failed to parse transactions: {}", e),
         };
 
-        if transaction_batches.len() == 0 {
+        if transaction_batches.is_empty() {
             panic!("SdkTestContext must be initialized with at least one transaction");
         }
 
@@ -305,6 +305,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[allow(clippy::needless_return)]
     async fn test_sdk_test_context() {
         let txn = Transaction {
             version: 100,
@@ -326,6 +327,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::needless_return)]
     async fn test_sdk_test_context_genesis() {
         let txn = Transaction {
             version: 1,
@@ -347,6 +349,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::needless_return)]
     async fn test_sdk_test_context_multiple_txns() {
         let txn1 = Transaction {
             version: 100,


### PR DESCRIPTION
### TL;DR
Enhanced the SdkTestContext to simplify test setup and improve transaction handling in the indexer processor testing framework.

### What changed?
- Refactored `SdkTestContext` to store and manage request versions internally
- Make `SdkTestContext` fields private so devs don't accidentally use `transaction_batches` incorrectly
- Added new helper methods `get_request_start_version()` and `get_transactions_count()` that will be used in processor tests
- Split server initialization into a separate `init_mock_grpc()` method. This is to make the constructor non-async which is generally encouraged. 
- Simplified `create_transaction_stream_config()` by removing manual version parameters

### Testing
cargo test