### PR TITLE
Add support for custom headers

### DIFF
--- a/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
+++ b/aptos-indexer-processors-sdk/testing-framework/src/sdk_test_context.rs
@@ -220,6 +220,7 @@ impl SdkTestContext {
             request_ending_version,
             auth_token: "".to_string(),
             request_name_header: "sdk-testing".to_string(),
+            additional_headers: Default::default(),
             indexer_grpc_http2_ping_interval_secs: 30,
             indexer_grpc_http2_ping_timeout_secs: 10,
             indexer_grpc_reconnection_timeout_secs: 10,

--- a/aptos-indexer-processors-sdk/transaction-stream/src/config.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/config.rs
@@ -1,3 +1,4 @@
+use crate::utils::AdditionalHeaders;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use url::Url;
@@ -10,6 +11,8 @@ pub struct TransactionStreamConfig {
     pub request_ending_version: Option<u64>,
     pub auth_token: String,
     pub request_name_header: String,
+    #[serde(default)]
+    pub additional_headers: AdditionalHeaders,
     #[serde(default = "TransactionStreamConfig::default_indexer_grpc_http2_ping_interval")]
     pub indexer_grpc_http2_ping_interval_secs: u64,
     #[serde(default = "TransactionStreamConfig::default_indexer_grpc_http2_ping_timeout")]

--- a/aptos-indexer-processors-sdk/transaction-stream/src/lib.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/lib.rs
@@ -4,3 +4,4 @@ pub mod utils;
 
 pub use config::TransactionStreamConfig;
 pub use transaction_stream::{TransactionStream, TransactionsPBResponse};
+pub use utils::AdditionalHeaders;

--- a/aptos-indexer-processors-sdk/transaction-stream/src/transaction_stream.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/transaction_stream.rs
@@ -1,4 +1,7 @@
-use crate::{config::TransactionStreamConfig, utils::timestamp_to_iso};
+use crate::{
+    config::TransactionStreamConfig,
+    utils::{timestamp_to_iso, AdditionalHeaders},
+};
 use anyhow::{anyhow, Result};
 use aptos_moving_average::MovingAverage;
 use aptos_protos::{
@@ -46,6 +49,7 @@ pub fn grpc_request_builder(
     transactions_count: Option<u64>,
     grpc_auth_token: String,
     request_name_header: String,
+    additional_headers: AdditionalHeaders,
 ) -> tonic::Request<GetTransactionsRequest> {
     let mut request = tonic::Request::new(GetTransactionsRequest {
         starting_version,
@@ -62,6 +66,7 @@ pub fn grpc_request_builder(
         GRPC_REQUEST_NAME_HEADER,
         request_name_header.parse().unwrap(),
     );
+    additional_headers.drain_into_metadata_map(request.metadata_mut());
     request
 }
 
@@ -195,6 +200,7 @@ pub async fn get_stream(
                     count,
                     transaction_stream_config.auth_token.clone(),
                     transaction_stream_config.request_name_header.clone(),
+                    transaction_stream_config.additional_headers.clone(),
                 );
                 rpc_client.get_transactions(request).await
             },

--- a/aptos-indexer-processors-sdk/transaction-stream/src/utils/additional_headers.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/utils/additional_headers.rs
@@ -1,0 +1,56 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, str::FromStr};
+use tonic::metadata::{Ascii, MetadataKey, MetadataMap, MetadataValue};
+
+/// This struct holds additional headers that we attach to the request metadata.
+/// Regarding serde, we just serialize this as we would a HashMap<String, String>.
+/// Similarly, we expect that format when deserializing.
+///
+/// It is necessary to use HashMap because there is no extend method on MetadataMap
+/// itself, nor does it implement Serialize / Deserialize. It is better to parse once
+/// here right at config validation time anyway, it exposes any error as early as
+/// possible and saves us doing parsing (perhaps multiple times) later.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(try_from = "HashMap<String, String>")]
+#[serde(into = "HashMap<String, String>")]
+pub struct AdditionalHeaders(HashMap<MetadataKey<Ascii>, MetadataValue<Ascii>>);
+
+impl AdditionalHeaders {
+    pub fn drain_into_metadata_map(self, metadata_map: &mut MetadataMap) {
+        for (key, value) in self.0 {
+            metadata_map.insert(key, value);
+        }
+    }
+}
+
+impl TryFrom<HashMap<String, String>> for AdditionalHeaders {
+    type Error = anyhow::Error;
+
+    /// Build `AdditionalHeaders` from just a map of strings. This can fail if the
+    /// strings contain invalid characters for metadata keys / values, the chars must
+    /// only be visible ascii characters.
+    fn try_from(map: HashMap<String, String>) -> Result<Self, Self::Error> {
+        let mut out = HashMap::new();
+        for (k, v) in map {
+            let k = MetadataKey::from_str(&k)
+                .with_context(|| format!("Failed to parse key as ascii metadata key: {}", k))?;
+            let v = MetadataValue::from_str(&v)
+                .with_context(|| format!("Failed to parse value as ascii metadata value: {}", v))?;
+            out.insert(k, v);
+        }
+        Ok(AdditionalHeaders(out))
+    }
+}
+
+impl From<AdditionalHeaders> for HashMap<String, String> {
+    fn from(headers: AdditionalHeaders) -> Self {
+        headers
+            .0
+            .into_iter()
+            // It is safe to unwrap here because when building this we asserted that the
+            // MetadataValue only contained visible ascii characters.
+            .map(|(k, v)| (k.as_str().to_owned(), v.to_str().unwrap().to_owned()))
+            .collect()
+    }
+}

--- a/aptos-indexer-processors-sdk/transaction-stream/src/utils/mod.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/utils/mod.rs
@@ -1,3 +1,6 @@
+mod additional_headers;
+
+pub use additional_headers::AdditionalHeaders;
 use aptos_protos::util::timestamp::Timestamp;
 
 // 9999-12-31 23:59:59, this is the max supported by Google BigQuery


### PR DESCRIPTION
## Summary
Sometimes the upstream txn stream might auth in a different way than with the `authorization: Bearer <key>` approach. This makes it possible to do so by adding support for custom headers.

## Test Plan
Tested by hand for now, connections and reconnections work correctly.