### PR TITLE
update testing framework cli arg

### DIFF
--- a/.github/workflows/update-processor-sdk-version-legacy.yaml
+++ b/.github/workflows/update-processor-sdk-version-legacy.yaml
@@ -1,0 +1,64 @@
+name: Update Processor SDK Version
+'on':
+  pull_request:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
+    branches:
+      - main
+    paths:
+      # Be conservative and only run this workflow when the Cargo.toml file changes.
+      # Reason: if SDK version is not updated, no change will be picked up by processors.
+      - aptos-indexer-processors-sdk/Cargo.toml
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  update-processor-sdk-version:
+    runs-on: ubuntu-latest
+    # Only run on each PR once an appropriate event occurs
+    if: |
+      (
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'indexer-sdk-update')
+      )
+    steps:
+      - id: auth
+        uses: "google-github-actions/auth@v2"
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+      - name: Get Secret Manager Secrets
+        id: secrets
+        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        with:
+          secrets: |-
+            token:aptos-ci/github-actions-repository-dispatch
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.secrets.outputs.token }}
+      - name: Capture the commit hash
+        id: commit_hash
+        run: |
+          # Echo the commit hash to the output
+          echo "::set-output name=commit_hash::$(echo $GITHUB_SHA)"
+          # Echo the PR branch name to the output
+          echo "::set-output name=branch_name::${{ github.head_ref }}"
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install toml
+        run: cargo install toml-cli
+      - name: Capture aptos-protos commit hash
+        id: aptos_protos_commit_hash
+        run: |
+          cd aptos-indexer-processors-sdk
+          aptos_protos_commit_hash=$(toml get Cargo.toml workspace.dependencies.aptos-protos.rev)
+          echo "::set-output name=aptos_protos_commit_hash::${aptos_protos_commit_hash}"
+      - name: Dispatch Event to processors Repo
+        uses: peter-evans/repository-dispatch@v3.0.0
+        with:
+          token: ${{ steps.secrets.outputs.token }}
+          repository: 'aptos-labs/aptos-indexer-processors'
+          event-type: 'sdk-dependency-update'
+          client-payload: '{"commit_hash": "${{ github.sha }}", "branch_name": "${{ steps.commit_hash.outputs.branch_name }}", "aptos_protos_commit_hash": ${{ steps.aptos_protos_commit_hash.outputs.aptos_protos_commit_hash }}}'

--- a/aptos-indexer-processors-sdk/testing-framework/src/cli_parser.rs
+++ b/aptos-indexer-processors-sdk/testing-framework/src/cli_parser.rs
@@ -34,8 +34,8 @@ pub fn parse_test_args() -> TestArgs {
     // Collect custom arguments based on determined start position
     let custom_args: Vec<String> = raw_args[custom_args_start..].to_vec();
 
-    // Manually parse the "generate-output" flag
-    let generate_output_flag = custom_args.contains(&"generate-output".to_string());
+    // Manually parse the "generate" flag
+    let generate_flag = custom_args.contains(&"generate".to_string());
 
     // Manually parse the "--output-path" flag and get its associated value
     let output_path = custom_args
@@ -43,14 +43,14 @@ pub fn parse_test_args() -> TestArgs {
         .find(|args| args[0] == "output-path")
         .map(|args| args[1].clone());
 
-    println!("Parsed generate_output_flag: {}", generate_output_flag);
+    println!("Parsed generate flag: {}", generate_flag);
     println!(
         "Parsed output_path: {}",
         output_path.clone().unwrap_or_else(|| "None".to_string())
     );
 
     TestArgs {
-        generate_output: generate_output_flag,
+        generate_output: generate_flag,
         output_path,
     }
 }
@@ -68,8 +68,8 @@ mod tests {
             None => Vec::new(), // If no `--` is found, treat as no custom args
         };
 
-        // Manually parse the "--generate-output" flag
-        let generate_output_flag = custom_args.contains(&"generate-output".to_string());
+        // Manually parse the "--generate" flag
+        let generate_output_flag = custom_args.contains(&"generate".to_string());
 
         // Manually parse the "--output-path" flag and get its associated value
         let output_path = custom_args
@@ -94,7 +94,7 @@ mod tests {
         let args = vec![
             "test_binary".to_string(),
             "--".to_string(),
-            "generate-output".to_string(),
+            "generate".to_string(),
         ];
         let parsed = parse_test_args_from_vec(args);
         assert!(parsed.generate_output);
@@ -119,7 +119,7 @@ mod tests {
         let args = vec![
             "test_binary".to_string(),
             "--".to_string(),
-            "generate-output".to_string(),
+            "generate".to_string(),
             "output-path".to_string(),
             "/some/other/path".to_string(),
         ];


### PR DESCRIPTION
### TL;DR
Renamed the CLI flag from `generate-output` to `generate` for improved usability.

### What changed?
- Changed the CLI flag from `generate-output` to `generate`

### How to test?


![Screenshot 2025-02-06 at 4.46.03 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XVbPtMdqqe4K1PNnLQvf/65494270-5afe-42a8-a467-a4567abcd2cb.png)

