### PR TITLE
lock kanal

### DIFF
--- a/aptos-indexer-processors-sdk/Cargo.lock
+++ b/aptos-indexer-processors-sdk/Cargo.lock
@@ -2013,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "kanal"
-version = "0.1.0"
+version = "0.1.0-pre8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b13526b910349296b1d3537ae62d5f83def9b6d6974e26d62b80ee2bb1b4794"
+checksum = "b05d55519627edaf7fd0f29981f6dc03fb52df3f5b257130eb8d0bf2801ea1d7"
 dependencies = [
  "futures-core",
  "lock_api",

--- a/aptos-indexer-processors-sdk/Cargo.toml
+++ b/aptos-indexer-processors-sdk/Cargo.toml
@@ -68,7 +68,9 @@ jemallocator = { version = "0.5.0", features = [
     "profiling",
     "unprefixed_malloc_on_supported_platforms",
 ] }
-kanal = "0.1.0"
+# Locking this because newer versions of kanal are using the unstable feature error_in_core, which
+# will break the Aptos CLI. 
+kanal = "=0.1.0-pre8"
 lazy_static = "1.4.0"
 mockall = "0.12.1"
 num_cpus = "1.16.0"

--- a/aptos-indexer-processors-sdk/instrumented-channel/src/lib.rs
+++ b/aptos-indexer-processors-sdk/instrumented-channel/src/lib.rs
@@ -22,7 +22,7 @@ async fn main() {
 }
 ```
  **/
-use kanal::{AsyncReceiver, AsyncSender, CloseError, ReceiveError, SendError};
+use kanal::{AsyncReceiver, AsyncSender, ReceiveError, SendError};
 
 pub struct InstrumentedAsyncSender<T> {
     pub(crate) sender: AsyncSender<T>,
@@ -41,7 +41,7 @@ impl<T> InstrumentedAsyncSender<T> {
             pub fn capacity(&self);
             pub fn receiver_count(&self) -> u32;
             pub fn sender_count(&self) -> u32;
-            pub fn close(&self) -> Result<(), CloseError>;
+            pub fn close(&self) -> bool;
             pub fn is_closed(&self) -> bool;
         }
     }
@@ -102,7 +102,7 @@ impl<T> InstrumentedAsyncReceiver<T> {
             pub fn capacity(&self);
             pub fn receiver_count(&self) -> u32;
             pub fn sender_count(&self) -> u32;
-            pub fn close(&self) -> Result<(), CloseError>;
+            pub fn close(&self) -> bool;
             pub fn is_closed(&self) -> bool;
         }
     }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1769,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "kanal"
-version = "0.1.0"
+version = "0.1.0-pre8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b13526b910349296b1d3537ae62d5f83def9b6d6974e26d62b80ee2bb1b4794"
+checksum = "b05d55519627edaf7fd0f29981f6dc03fb52df3f5b257130eb8d0bf2801ea1d7"
 dependencies = [
  "futures-core",
  "lock_api",


### PR DESCRIPTION
Lock the kanal crate to 0.1.0-pre8 because a newer version is using the unstable feature error_in_core, which will break the Aptos CLI. 