### PR TITLE
Add timeout and max reconnection retries to grpc stream

### DIFF
--- a/aptos-indexer-processors-sdk/sdk/src/testing_framework/sdk_test_context.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/testing_framework/sdk_test_context.rs
@@ -225,6 +225,7 @@ impl SdkTestContext {
             indexer_grpc_http2_ping_timeout_secs: 10,
             indexer_grpc_reconnection_timeout_secs: 10,
             indexer_grpc_response_item_timeout_secs: 60,
+            indexer_grpc_reconnection_max_retries: Default::default(),
             transaction_filter: None,
         }
     }

--- a/aptos-indexer-processors-sdk/transaction-stream/src/config.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/config.rs
@@ -22,6 +22,8 @@ pub struct TransactionStreamConfig {
     pub indexer_grpc_reconnection_timeout_secs: u64,
     #[serde(default = "TransactionStreamConfig::default_indexer_grpc_response_item_timeout")]
     pub indexer_grpc_response_item_timeout_secs: u64,
+    #[serde(default = "TransactionStreamConfig::default_indexer_grpc_reconnection_max_retries")]
+    pub indexer_grpc_reconnection_max_retries: u64,
     #[serde(default)]
     pub transaction_filter: Option<BooleanTransactionFilter>,
 }
@@ -62,5 +64,10 @@ impl TransactionStreamConfig {
     /// Default timeout for receiving an item from grpc stream. Defaults to 60 seconds.
     pub const fn default_indexer_grpc_response_item_timeout() -> u64 {
         60
+    }
+
+    /// Default max retries for reconnecting to grpc. Defaults to 100.
+    pub const fn default_indexer_grpc_reconnection_max_retries() -> u64 {
+        5
     }
 }


### PR DESCRIPTION
This PR adds a timeout to get the chain ID from GRPC. It's needed in the Aptos CLI because GRPC takes some time to start up. Without the timeout, the processors will fail at the chain id check. The timeout and max reconnection retries are configurable in config. 