### PR TITLE
sleep when pollable step is waiting for next poll

### DIFF
--- a/aptos-indexer-processors-sdk/sdk/src/postgres/utils/database.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/postgres/utils/database.rs
@@ -44,7 +44,7 @@ pub fn clean_data_for_db<T: serde::Serialize + for<'de> serde::Deserialize<'de>>
     }
 }
 
-fn establish_connection(database_url: &str) -> BoxFuture<ConnectionResult<AsyncPgConnection>> {
+fn establish_connection(database_url: &str) -> BoxFuture<'_, ConnectionResult<AsyncPgConnection>> {
     use native_tls::{Certificate, TlsConnector};
     use postgres_native_tls::MakeTlsConnector;
 


### PR DESCRIPTION
## Description
Aptos CLI with localnet is using too much CPU. Flamegraph points to PollableAsyncStep as the culprit. When PollableAsyncStep is waiting for the next poll, it should sleep and stop trying to acquire the mutex lock on the step. 

## Testing 
Before (no change) 

![Screenshot 2025-07-16 at 3.04.12 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vIwavW9noSx0eb70aDLz/1a54aea1-1a24-45b4-bc6c-8c50f245c1c2.png)

`aptos node run-local-testnet --force-restart --assume-yes` (without indexer api)
![Screenshot 2025-07-16 at 2.37.32 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vIwavW9noSx0eb70aDLz/709b2ad9-6fd5-4ed9-b007-d6a339335a0d.png)

`aptos node run-local-testnet --force-restart --assume-yes --with-indexer-api` 

![Screenshot 2025-07-16 at 2.32.56 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vIwavW9noSx0eb70aDLz/3021fd53-847e-468d-b5b0-ccf12ee8e599.png)
