### PR TITLE
Make run_processor in basic_processor_function.rs public

### DIFF
--- a/aptos-indexer-processors-sdk/sdk/src/postgres/basic_processor/basic_processor_function.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/postgres/basic_processor/basic_processor_function.rs
@@ -79,7 +79,7 @@ where
     }
 }
 
-async fn run_processor<F, Fut>(
+pub async fn run_processor<F, Fut>(
     processor_name: String,
     transaction_stream_config: TransactionStreamConfig,
     postgres_config: PostgresConfig,

--- a/aptos-indexer-processors-sdk/sdk/src/postgres/basic_processor/mod.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/postgres/basic_processor/mod.rs
@@ -1,4 +1,4 @@
 pub mod basic_processor_function;
 pub mod basic_processor_step;
 
-pub use basic_processor_function::process;
+pub use basic_processor_function::{process, run_processor};


### PR DESCRIPTION
Sometimes you can't use `process` because you might want to read the config differently. In that case `run_processor` is a helpful function because it still does everything else you want. Let's make it public.