### PR TITLE
Add proactive failback to primary gRPC endpoint

### DIFF
--- a/aptos-indexer-processors-sdk/sdk/src/testing_framework/sdk_test_context.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/testing_framework/sdk_test_context.rs
@@ -226,6 +226,7 @@ impl SdkTestContext {
             reconnection_config: Default::default(),
             transaction_filter: None,
             backup_endpoints: vec![],
+            primary_failback_interval_secs: 0,
         }
     }
 }

--- a/aptos-indexer-processors-sdk/transaction-stream/src/config.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/config.rs
@@ -119,6 +119,10 @@ pub struct TransactionStreamConfig {
     /// Backup gRPC endpoints for failover. Tried in order after primary fails.
     #[serde(default)]
     pub backup_endpoints: Vec<Endpoint>,
+    /// How often (in seconds) to probe the primary endpoint while on a backup.
+    /// Set to 0 to disable proactive failback. Default: 60.
+    #[serde(default = "TransactionStreamConfig::default_primary_failback_interval")]
+    pub primary_failback_interval_secs: u64,
 }
 
 impl TransactionStreamConfig {
@@ -145,6 +149,14 @@ impl TransactionStreamConfig {
 
     pub const fn default_indexer_grpc_response_item_timeout() -> u64 {
         60
+    }
+
+    pub const fn default_primary_failback_interval() -> u64 {
+        10
+    }
+
+    pub const fn primary_failback_interval(&self) -> Duration {
+        Duration::from_secs(self.primary_failback_interval_secs)
     }
 
     /// Total number of endpoints (primary + backups).

--- a/aptos-indexer-processors-sdk/transaction-stream/src/config.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/config.rs
@@ -120,7 +120,7 @@ pub struct TransactionStreamConfig {
     #[serde(default)]
     pub backup_endpoints: Vec<Endpoint>,
     /// How often (in seconds) to probe the primary endpoint while on a backup.
-    /// Set to 0 to disable proactive failback. Default: 60.
+    /// Set to 0 to disable proactive failback. Default: 10.
     #[serde(default = "TransactionStreamConfig::default_primary_failback_interval")]
     pub primary_failback_interval_secs: u64,
 }

--- a/aptos-indexer-processors-sdk/transaction-stream/src/transaction_stream.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/transaction_stream.rs
@@ -384,6 +384,7 @@ pub struct TransactionStream {
     reconnection_retries: u64,
     last_fetched_version: Option<i64>,
     fetch_ma: MovingAverage,
+    primary_endpoint: Endpoint,
     current_endpoint_is_primary: bool,
     current_endpoint_address: String,
     /// When we last attempted (or considered) a failback probe to the primary.
@@ -393,6 +394,7 @@ pub struct TransactionStream {
 impl TransactionStream {
     pub async fn new(transaction_stream_config: TransactionStreamConfig) -> Result<Self> {
         let endpoints = transaction_stream_config.get_endpoints();
+        let primary_endpoint = endpoints[0].clone();
 
         let mut last_error = None;
         for endpoint in endpoints.iter() {
@@ -413,6 +415,7 @@ impl TransactionStream {
                             .starting_version
                             .map(|v| v as i64 - 1),
                         fetch_ma: MovingAverage::new(3000),
+                        primary_endpoint,
                         current_endpoint_is_primary: endpoint.is_primary,
                         current_endpoint_address: endpoint.address.to_string(),
                         last_primary_check: tokio::time::Instant::now(),
@@ -622,17 +625,8 @@ impl TransactionStream {
             return;
         }
 
-        let primary_endpoint = Endpoint {
-            address: self
-                .transaction_stream_config
-                .indexer_grpc_data_service_address
-                .clone(),
-            auth_token: self.transaction_stream_config.auth_token.clone(),
-            is_primary: true,
-        };
-
         info!(
-            primary_address = primary_endpoint.address.to_string(),
+            primary_address = self.primary_endpoint.address.to_string(),
             backup_address = self.current_endpoint_address,
             "[Transaction Stream] Attempting failback to primary endpoint"
         );
@@ -646,7 +640,7 @@ impl TransactionStream {
         let probe_timeout = Duration::from_secs(5);
         let probe_result = tokio::time::timeout(
             probe_timeout,
-            get_stream_for_endpoint(probe_config, &primary_endpoint),
+            get_stream_for_endpoint(probe_config, &self.primary_endpoint),
         )
         .await;
 
@@ -663,7 +657,7 @@ impl TransactionStream {
                 self.connection_id = connection_id;
                 self.stream = response.into_inner();
                 self.current_endpoint_is_primary = true;
-                self.current_endpoint_address = primary_endpoint.address.to_string();
+                self.current_endpoint_address = self.primary_endpoint.address.to_string();
                 info!(
                     stream_address = self.current_endpoint_address,
                     connection_id = self.connection_id,
@@ -672,14 +666,14 @@ impl TransactionStream {
             },
             Ok(Err(e)) => {
                 info!(
-                    primary_address = primary_endpoint.address.to_string(),
+                    primary_address = self.primary_endpoint.address.to_string(),
                     error = ?e,
                     "[Transaction Stream] Primary endpoint not yet healthy, staying on backup"
                 );
             },
             Err(_) => {
                 info!(
-                    primary_address = primary_endpoint.address.to_string(),
+                    primary_address = self.primary_endpoint.address.to_string(),
                     "[Transaction Stream] Primary endpoint probe timed out, staying on backup"
                 );
             },

--- a/aptos-indexer-processors-sdk/transaction-stream/src/transaction_stream.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/transaction_stream.rs
@@ -385,6 +385,9 @@ pub struct TransactionStream {
     last_fetched_version: Option<i64>,
     fetch_ma: MovingAverage,
     current_endpoint_is_primary: bool,
+    current_endpoint_address: String,
+    /// When we last attempted (or considered) a failback probe to the primary.
+    last_primary_check: tokio::time::Instant,
 }
 
 impl TransactionStream {
@@ -411,6 +414,8 @@ impl TransactionStream {
                             .map(|v| v as i64 - 1),
                         fetch_ma: MovingAverage::new(3000),
                         current_endpoint_is_primary: endpoint.is_primary,
+                        current_endpoint_address: endpoint.address.to_string(),
+                        last_primary_check: tokio::time::Instant::now(),
                     });
                 },
                 Err(e) => {
@@ -465,6 +470,9 @@ impl TransactionStream {
     ///    we will automatically reconnect and retry.
     pub async fn get_next_transaction_batch(&mut self) -> Result<TransactionsPBResponse> {
         loop {
+            // If on a backup endpoint, periodically try to return to the primary.
+            self.try_failback_to_primary().await;
+
             let grpc_channel_recv_latency = std::time::Instant::now();
 
             let txn_pb_res = match tokio::time::timeout(
@@ -503,10 +511,7 @@ impl TransactionStream {
                         sample!(
                             SampleRate::Duration(Duration::from_secs(1)),
                             info!(
-                                stream_address = self
-                                    .transaction_stream_config
-                                    .indexer_grpc_data_service_address
-                                    .to_string(),
+                                stream_address = self.current_endpoint_address,
                                 connection_id = self.connection_id,
                                 start_version = start_version,
                                 end_version = end_version,
@@ -552,7 +557,7 @@ impl TransactionStream {
                     },
                     Some(Err(rpc_error)) => {
                         warn!(
-                            stream_address = self.transaction_stream_config.indexer_grpc_data_service_address.to_string(),
+                            stream_address = self.current_endpoint_address,
                             connection_id = self.connection_id,
                             start_version = self.transaction_stream_config.starting_version,
                             end_version = self.transaction_stream_config.request_ending_version,
@@ -563,10 +568,7 @@ impl TransactionStream {
                     },
                     None => {
                         warn!(
-                            stream_address = self
-                                .transaction_stream_config
-                                .indexer_grpc_data_service_address
-                                .to_string(),
+                            stream_address = self.current_endpoint_address,
                             connection_id = self.connection_id,
                             start_version = self.transaction_stream_config.starting_version,
                             end_version = self.transaction_stream_config.request_ending_version,
@@ -577,10 +579,7 @@ impl TransactionStream {
                 },
                 Err(_) => {
                     warn!(
-                        stream_address = self
-                            .transaction_stream_config
-                            .indexer_grpc_data_service_address
-                            .to_string(),
+                        stream_address = self.current_endpoint_address,
                         connection_id = self.connection_id,
                         start_version = self.transaction_stream_config.starting_version,
                         end_version = self.transaction_stream_config.request_ending_version,
@@ -605,6 +604,56 @@ impl TransactionStream {
             last_fetched_version >= ending_version as i64
         } else {
             false
+        }
+    }
+
+    /// If we are currently on a backup endpoint and enough time has elapsed,
+    /// probe the primary endpoint and switch back to it if healthy.
+    async fn try_failback_to_primary(&mut self) {
+        if self.current_endpoint_is_primary {
+            return;
+        }
+
+        let interval = self.transaction_stream_config.primary_failback_interval();
+        if interval.is_zero() || self.last_primary_check.elapsed() < interval {
+            return;
+        }
+
+        // Reset timer regardless of outcome to avoid hammering the primary.
+        self.last_primary_check = tokio::time::Instant::now();
+
+        let primary_endpoint = Endpoint {
+            address: self
+                .transaction_stream_config
+                .indexer_grpc_data_service_address
+                .clone(),
+            auth_token: self.transaction_stream_config.auth_token.clone(),
+            is_primary: true,
+        };
+
+        info!(
+            primary_address = primary_endpoint.address.to_string(),
+            backup_address = self.current_endpoint_address,
+            "[Transaction Stream] Attempting failback to primary endpoint"
+        );
+
+        match self.reconnect_to_grpc(&primary_endpoint).await {
+            Ok(_) => {
+                self.current_endpoint_is_primary = true;
+                self.current_endpoint_address = primary_endpoint.address.to_string();
+                info!(
+                    stream_address = self.current_endpoint_address,
+                    connection_id = self.connection_id,
+                    "[Transaction Stream] Successfully failed back to primary endpoint"
+                );
+            },
+            Err(e) => {
+                info!(
+                    primary_address = primary_endpoint.address.to_string(),
+                    error = ?e,
+                    "[Transaction Stream] Primary endpoint not yet healthy, staying on backup"
+                );
+            },
         }
     }
 
@@ -637,6 +686,8 @@ impl TransactionStream {
                 match self.reconnect_to_grpc(endpoint).await {
                     Ok(_) => {
                         self.current_endpoint_is_primary = endpoint.is_primary;
+                        self.current_endpoint_address = endpoint.address.to_string();
+                        self.last_primary_check = tokio::time::Instant::now();
                         return Ok(());
                     },
                     Err(e) => {

--- a/aptos-indexer-processors-sdk/transaction-stream/src/transaction_stream.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/src/transaction_stream.rs
@@ -609,6 +609,9 @@ impl TransactionStream {
 
     /// If we are currently on a backup endpoint and enough time has elapsed,
     /// probe the primary endpoint and switch back to it if healthy.
+    ///
+    /// The probe is a single, short-timeout connection attempt (5 seconds) so
+    /// it never blocks backup-stream processing for long.
     async fn try_failback_to_primary(&mut self) {
         if self.current_endpoint_is_primary {
             return;
@@ -618,9 +621,6 @@ impl TransactionStream {
         if interval.is_zero() || self.last_primary_check.elapsed() < interval {
             return;
         }
-
-        // Reset timer regardless of outcome to avoid hammering the primary.
-        self.last_primary_check = tokio::time::Instant::now();
 
         let primary_endpoint = Endpoint {
             address: self
@@ -637,8 +637,31 @@ impl TransactionStream {
             "[Transaction Stream] Attempting failback to primary endpoint"
         );
 
-        match self.reconnect_to_grpc(&primary_endpoint).await {
-            Ok(_) => {
+        // Build a probe-specific config with no retries so the attempt is a
+        // single, short-lived connection check that won't stall backup streaming.
+        let mut probe_config = self.transaction_stream_config.clone();
+        probe_config.starting_version = self.last_fetched_version.map(|v| (v + 1) as u64);
+        probe_config.reconnection_config.max_retries = 0;
+
+        let probe_timeout = Duration::from_secs(5);
+        let probe_result = tokio::time::timeout(
+            probe_timeout,
+            get_stream_for_endpoint(probe_config, &primary_endpoint),
+        )
+        .await;
+
+        // Reset timer *after* the probe so elapsed time always reflects
+        // wall-clock time since the last completed probe, not the start.
+        self.last_primary_check = tokio::time::Instant::now();
+
+        match probe_result {
+            Ok(Ok(response)) => {
+                let connection_id = match response.metadata().get(GRPC_CONNECTION_ID) {
+                    Some(id) => id.to_str().unwrap_or("").to_string(),
+                    None => "".to_string(),
+                };
+                self.connection_id = connection_id;
+                self.stream = response.into_inner();
                 self.current_endpoint_is_primary = true;
                 self.current_endpoint_address = primary_endpoint.address.to_string();
                 info!(
@@ -647,11 +670,17 @@ impl TransactionStream {
                     "[Transaction Stream] Successfully failed back to primary endpoint"
                 );
             },
-            Err(e) => {
+            Ok(Err(e)) => {
                 info!(
                     primary_address = primary_endpoint.address.to_string(),
                     error = ?e,
                     "[Transaction Stream] Primary endpoint not yet healthy, staying on backup"
+                );
+            },
+            Err(_) => {
+                info!(
+                    primary_address = primary_endpoint.address.to_string(),
+                    "[Transaction Stream] Primary endpoint probe timed out, staying on backup"
                 );
             },
         }

--- a/aptos-indexer-processors-sdk/transaction-stream/tests/failover_test.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/tests/failover_test.rs
@@ -162,6 +162,7 @@ fn create_base_config(primary_port: u16) -> TransactionStreamConfig {
         },
         transaction_filter: None,
         backup_endpoints: vec![],
+        primary_failback_interval_secs: 0,
     }
 }
 
@@ -254,6 +255,7 @@ async fn test_config_endpoint_helpers() {
                 is_primary: false,
             },
         ],
+        primary_failback_interval_secs: 0,
     };
 
     let endpoints = config.get_endpoints();

--- a/aptos-indexer-processors-sdk/transaction-stream/tests/stream_timeout_test.rs
+++ b/aptos-indexer-processors-sdk/transaction-stream/tests/stream_timeout_test.rs
@@ -174,6 +174,7 @@ async fn test_transaction_stream_reconnects_on_timeout() {
         },
         transaction_filter: None,
         backup_endpoints: vec![],
+        primary_failback_interval_secs: 0,
     };
 
     // Initialize the transaction stream (uses connection 1)


### PR DESCRIPTION
## Summary
- **Log active stream address**: All stream log messages (`Received transactions`, `Error receiving datastream`, `Stream ended`, `Response item timeout`) now show the actual active endpoint address instead of always the primary.
- **Proactive failback**: When the SDK is on a backup endpoint, it periodically probes the primary (configurable via `primary_failback_interval_secs`, default 10s) and switches back when healthy. Setting to 0 disables failback.
- **New config field**: `primary_failback_interval_secs` on `TransactionStreamConfig` controls the probe interval.

## Test plan
- [ ] Verify `cargo check` / `cargo test` pass on the `transaction-stream` crate
- [ ] Deploy with a backup endpoint configured, kill the primary, confirm failover to backup
- [ ] Restore the primary, confirm logs show failback probe attempts and successful switch back within ~10s
- [ ] Verify `primary_failback_interval_secs: 0` disables probing
- [ ] Confirm log messages show the correct active endpoint address throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies gRPC endpoint selection and reconnection behavior; incorrect timing/probing could cause extra reconnect churn or brief stream interruptions while on backups.
> 
> **Overview**
> Adds a new `TransactionStreamConfig.primary_failback_interval_secs` (default **10s**, `0` disables) to periodically probe the primary gRPC endpoint while streaming from a backup and automatically switch back when it becomes healthy.
> 
> Updates `TransactionStream` to track the active endpoint address for logging and to maintain primary/backup state during reconnects and failback probes, and wires the new config field through the SDK test context and existing transaction-stream tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5af9b258622328beffaaa819a56a57316c7539a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->