### PR TITLE
Redact Postgres password from migration startup log

### DIFF
--- a/aptos-indexer-processors-sdk/sdk/src/builder/processor_builder.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/builder/processor_builder.rs
@@ -159,7 +159,7 @@ impl GraphBuilder {
             let node = node_map.get(&node_val).unwrap();
 
             //let input_output = format!("{} -> {}", &node.input_type, &node.output_type);
-            let label = format!("label=\"{}\\n{}\"", &node.name, &node.step_type);
+            let label = format!("label=\"{}\\n{}\"", node.name, node.step_type);
             let shape = if node_val == 0 {
                 " shape=invhouse".to_string()
             } else if node.end_step {

--- a/aptos-indexer-processors-sdk/sdk/src/postgres/utils/database.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/postgres/utils/database.rs
@@ -4,7 +4,7 @@
 //! Database-related functions
 #![allow(clippy::extra_unused_lifetimes)]
 
-use crate::utils::{convert::remove_null_bytes, errors::ProcessorError};
+use crate::utils::{convert::remove_null_bytes, errors::ProcessorError, redact::redact_string};
 use ahash::AHashMap;
 use diesel::{ConnectionResult, QueryResult, query_builder::QueryFragment};
 use diesel_async::{
@@ -242,7 +242,7 @@ pub async fn run_migrations(
 ) {
     use diesel::{Connection, PgConnection};
 
-    info!("Running migrations: {:?}", postgres_connection_string);
+    info!("Running migrations: {}", redact_string(&postgres_connection_string));
     let migration_time = std::time::Instant::now();
     let mut conn =
         PgConnection::establish(&postgres_connection_string).expect("migrations failed!");
@@ -263,7 +263,7 @@ pub async fn run_migrations(
 ) {
     use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 
-    info!("Running migrations: {:?}", postgres_connection_string);
+    info!("Running migrations: {}", redact_string(&postgres_connection_string));
     let conn = conn_pool
         // We need to use this since AsyncConnectionWrapper doesn't know how to
         // work with a pooled connection.

--- a/aptos-indexer-processors-sdk/sdk/src/utils/extract.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/utils/extract.rs
@@ -303,8 +303,8 @@ pub fn get_clean_entry_function_payload_from_user_request(
     user_request: &UserTransactionRequest,
     version: i64,
 ) -> Option<EntryFunctionPayloadClean> {
-    let clean_payload: Option<EntryFunctionPayloadClean> = match &user_request.payload {
-        Some(txn_payload) => match &txn_payload.payload {
+    let txn_payload = user_request.payload.as_ref()?;
+    let clean_payload: Option<EntryFunctionPayloadClean> = match &txn_payload.payload {
             Some(PayloadType::EntryFunctionPayload(payload)) => {
                 Some(get_clean_entry_function_payload(payload, version))
             },
@@ -339,9 +339,7 @@ pub fn get_clean_entry_function_payload_from_user_request(
                     None => None,
                 }
             },
-            _ => return None,
-        },
-        None => return None,
+        _ => None,
     };
     clean_payload
 }

--- a/aptos-indexer-processors-sdk/sdk/src/utils/mod.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/utils/mod.rs
@@ -4,4 +4,5 @@ pub mod convert;
 pub mod errors;
 pub mod extract;
 pub mod property_map;
+pub mod redact;
 pub mod step_metrics;

--- a/aptos-indexer-processors-sdk/sdk/src/utils/redact.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/utils/redact.rs
@@ -7,13 +7,11 @@ pub fn redact_string(url: &str) -> String {
     };
 
     // Redact password in the authority (user:pass@host) section.
-    if parsed.password().is_some() {
-        if parsed.set_password(Some("REDACTED")).is_err() {
-            // set_password fails only when the URL has no host, which cannot
-            // happen when password() returned Some — but return a safe fallback
-            // rather than leak credentials.
-            return "[connection string]".to_string();
-        }
+    if parsed.password().is_some() && parsed.set_password(Some("REDACTED")).is_err() {
+        // set_password fails only when the URL has no host, which cannot
+        // happen when password() returned Some — but return a safe fallback
+        // rather than leak credentials.
+        return "[connection string]".to_string();
     }
 
     // Redact password supplied as a query parameter (e.g. ?password=secret).

--- a/aptos-indexer-processors-sdk/sdk/src/utils/redact.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/utils/redact.rs
@@ -1,0 +1,41 @@
+use url::Url;
+
+pub fn redact_string(url: &str) -> String {
+    let mut parsed = match Url::parse(url) {
+        Ok(u) => u,
+        Err(_) => return "[unparseable connection string]".to_string(),
+    };
+    if parsed.password().is_some() {
+        parsed.set_password(Some("REDACTED")).ok();
+    }
+    parsed.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_redact_password() {
+        assert_eq!(
+            redact_string("postgres://user:secret@localhost:5432/mydb"),
+            "postgres://user:REDACTED@localhost:5432/mydb"
+        );
+    }
+
+    #[test]
+    fn test_no_password() {
+        assert_eq!(
+            redact_string("postgres://user@localhost:5432/mydb"),
+            "postgres://user@localhost:5432/mydb"
+        );
+    }
+
+    #[test]
+    fn test_unparseable() {
+        assert_eq!(
+            redact_string("not a url"),
+            "[unparseable connection string]"
+        );
+    }
+}

--- a/aptos-indexer-processors-sdk/sdk/src/utils/redact.rs
+++ b/aptos-indexer-processors-sdk/sdk/src/utils/redact.rs
@@ -5,9 +5,39 @@ pub fn redact_string(url: &str) -> String {
         Ok(u) => u,
         Err(_) => return "[unparseable connection string]".to_string(),
     };
+
+    // Redact password in the authority (user:pass@host) section.
     if parsed.password().is_some() {
-        parsed.set_password(Some("REDACTED")).ok();
+        if parsed.set_password(Some("REDACTED")).is_err() {
+            // set_password fails only when the URL has no host, which cannot
+            // happen when password() returned Some — but return a safe fallback
+            // rather than leak credentials.
+            return "[connection string]".to_string();
+        }
     }
+
+    // Redact password supplied as a query parameter (e.g. ?password=secret).
+    let has_password_param = parsed.query_pairs().any(|(k, _)| k == "password");
+    if has_password_param {
+        let new_pairs: Vec<(String, String)> = parsed
+            .query_pairs()
+            .map(|(k, v)| {
+                if k.as_ref() == "password" {
+                    (k.into_owned(), "REDACTED".to_string())
+                } else {
+                    (k.into_owned(), v.into_owned())
+                }
+            })
+            .collect();
+        {
+            let mut qpm = parsed.query_pairs_mut();
+            qpm.clear();
+            for (k, v) in &new_pairs {
+                qpm.append_pair(k, v);
+            }
+        }
+    }
+
     parsed.to_string()
 }
 
@@ -16,7 +46,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_redact_password() {
+    fn test_redact_authority_password() {
         assert_eq!(
             redact_string("postgres://user:secret@localhost:5432/mydb"),
             "postgres://user:REDACTED@localhost:5432/mydb"
@@ -36,6 +66,22 @@ mod tests {
         assert_eq!(
             redact_string("not a url"),
             "[unparseable connection string]"
+        );
+    }
+
+    #[test]
+    fn test_redact_query_param_password() {
+        assert_eq!(
+            redact_string("postgresql://user@localhost:5432/mydb?password=secret"),
+            "postgresql://user@localhost:5432/mydb?password=REDACTED"
+        );
+    }
+
+    #[test]
+    fn test_redact_query_param_password_only() {
+        assert_eq!(
+            redact_string("postgresql:///mydb?user=u&password=secret"),
+            "postgresql:///mydb?user=u&password=REDACTED"
         );
     }
 }


### PR DESCRIPTION
## Summary
Fixes a credential leak where `run_migrations` logged the full Postgres DSN (including the password) at INFO level on every processor startup, exposing secrets in centralized log aggregators.

## Changes
- Add `utils::redact::redact_string` — parses the DSN with the `url` crate, replaces the password segment with `REDACTED`, and falls back gracefully for non-URL strings
- Export `redact` from `utils/mod.rs`
- Replace both `run_migrations` log lines (the `postgres_full` and non-`postgres_full` cfg variants) to use `redact_string` before logging

## Test Plan
- [ ] `cargo build -p aptos-indexer-processor-sdk` — compiles clean under both feature flags
- [ ] `cargo test -p aptos-indexer-processor-sdk utils::redact` — 3 unit tests pass (password redacted, no-password passthrough, unparseable fallback)
- [ ] Start a processor against a real DB and confirm logs show `postgres://user:REDACTED@host:port/db` instead of the raw password

<details>
<summary>Decisions & Tradeoffs</summary>

- **Redaction approach**: Chose a dedicated `utils::redact::redact_string` helper over an inline one-liner — follows the existing `utils::convert::remove_null_bytes` pattern and makes the utility reusable for any future call site that logs a DSN
- **Log content**: Chose to keep the sanitized URL (host/port/database) rather than dropping the connection string entirely — preserves debugging context (which host migrations ran against) while eliminating the secret

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily changes logging to avoid leaking Postgres credentials, plus small refactors that should not affect core processing behavior.
> 
> **Overview**
> Prevents Postgres credentials from being logged during processor startup by introducing `utils::redact::redact_string` and using it in both `run_migrations` implementations before emitting the INFO log line.
> 
> Also includes a small cleanup in `get_clean_entry_function_payload_from_user_request` to use early-return (`?`) option handling, and a minor formatting tweak in graph DOT label generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16a4beef27ed9731457d4bdd516becbb040fd6d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->